### PR TITLE
Fix Bug 730178 - Update button is not shown even though extension update...

### DIFF
--- a/gtweak/tweaks/tweak_group_shell_extensions.py
+++ b/gtweak/tweaks/tweak_group_shell_extensions.py
@@ -311,9 +311,10 @@ class ShellExtensionTweakGroup(ListBoxTweakGroup):
             resp = resp['shell_version_map']
             shell = GnomeShellFactory().get_shell()
             version = _fix_shell_version_for_ego(shell.version)
+            major_minor_version = _get_shell_major_minor_version(shell.version)
 
-            if version in resp:
-                resp = resp[version]
+            if version in resp or major_minor_version in resp:
+                resp = resp[version] if version in resp else resp[major_minor_version]
                 ext_version = extension["version"] if "version" in extension else 0
                 if int(resp["version"]) > ext_version:
                     widget.add_update_button(uuid)


### PR DESCRIPTION
...s are available

Some extension advertise only major+minor shell version in version map, so if a user
uses a patched version, e.g. 3.10.2, then update button is not shown at those
extensions even though they support shell 3.10 and the installed version does
not.

The fix changes the check to look for major+minor+patch version (3.10.2) or major+minor shell version (3.10) in extension's version map.
